### PR TITLE
fix(config/database): use FQN \Pdo\Mysql for PHP 8.5 MySQL SSL constant

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
             'unix_socket' => env('DB_SOCKET', ''),
             'prefix_indexes' => true,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Summary

Fixes a fatal `Class "Mysql" not found` at `config/database.php:40` on **PHP 8.5+ with Laravel 13**. The fatal happens during the `LoadConfiguration` bootstrapper — **before** Laravel's logger is initialized — so it manifests as a silent empty-body 500 with no entry in `storage/logs/laravel.log`. It blocks every request to a Laravel 13 app running on PHP 8.5.

Surfaced by the PHP 8.5 functional smoke (df-base-img PR https://github.com/dreamfactorysoftware/df-docker-base/pull/18).

## Root cause

`config/database.php` is a plain `return [...]` config file with no namespace declaration and no `use` statements. Line 40 contains a PHP-version-conditional reference to a SSL CA constant:

```php
'options' => extension_loaded('pdo_mysql') ? array_filter([
    (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
]) : [],
```

The unqualified `Mysql::ATTR_SSL_CA` resolves to the **global** `\Mysql` class, which does not exist. The actual symbol is `\Pdo\Mysql::ATTR_SSL_CA` — the namespaced PDO subclass introduced in PHP 8.4.

This is a Laravel 13 reference-template bug (the same code shape appears in `laravel/laravel#13.x`). It only fatals on PHP 8.5+ where the ternary takes the broken branch; on PHP 8.3/8.4 the legacy `PDO::MYSQL_ATTR_SSL_CA` path is taken and the bug is dormant.

## Fix

```diff
-                (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
```

Single-line change. Could equivalently be solved by adding `use Pdo\Mysql;` at the top of the file, but FQN is more in keeping with Laravel's other config files which never declare imports.

## Verification

Live test against PHP 8.5.5 + Laravel 13.8.0:

**Before fix:**
- Every request returns 500 with empty body (1017 bytes of Symfony fallback HTML)
- `storage/logs/laravel.log` shows the actual error: `Class "Mysql" not found at /opt/dreamfactory/config/database.php:40`
- Followed by `EMERGENCY: Unable to create configured logger. Using emergency logger. Log [] is not defined.` — confirming logger isn't yet up when the fatal fires

**After fix (combined with df-core CorsServiceProvider PR):**
- `GET /api/v2/system/environment` → 400 JSON (expected unauthenticated response)
- `GET /` → 302 redirect to /setup (expected first-time-setup flow)
- Full Laravel boot completes cleanly; no fatal at config-load

## Compat note

The PHP 8.3/8.4 branch (`PDO::MYSQL_ATTR_SSL_CA`) is untouched. Existing deployments are unaffected; this fix only changes behavior on PHP 8.5+ where the buggy branch was previously fatal.