### PR TITLE
Bump app version to 7.7.0

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Facade;
 
 return [
 
-    'version' => '7.5.0',
+    'version' => '7.7.0',
 
     'license_key' => env('DF_LICENSE_KEY', false),
 


### PR DESCRIPTION
The 7.7 branch's `config/app.php` still says `'version' => '7.5.0'` — it's a hardcoded literal (not env-wrapped) and is what `/api/v2/system/environment` reports as `platform.version` (via df-system's Environment resource), so 7.7 test instances label themselves 7.5.0 in the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)